### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/Season-2/Level-2/code.go
+++ b/Season-2/Level-2/code.go
@@ -70,7 +70,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if password == storedPassword {
-			log.Printf("User %q logged in successfully with a valid password %q", email, password)
+			log.Printf("User %q logged in successfully", email)
 			w.WriteHeader(http.StatusOK)
 		} else {
 			http.Error(w, "Invalid Email or Password", http.StatusUnauthorized)


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/vigilant-octo/security/code-scanning/14](https://github.com/akabarki76/vigilant-octo/security/code-scanning/14)

To fix the issue, the sensitive `password` variable should not be logged in clear text. Instead, the logging statement should be modified to exclude the password entirely or obfuscate it. The best approach is to log only the email address and a success message, as this provides sufficient information for debugging without exposing sensitive data.

Changes to be made:
1. Modify the logging statement on line 73 to exclude the `password` variable.
2. Ensure that the functionality of the code remains unchanged and that the test cases in `code_test.go` still pass.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
