### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/Season-2/Level-3/code.js
+++ b/Season-2/Level-3/code.js
@@ -15,6 +15,7 @@ const libxmljs = require("libxmljs");
 const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
+const sanitizeFilename = require("sanitize-filename");
 const { exec } = require("node:child_process");
 const RateLimit = require("express-rate-limit");
 const app = express();
@@ -37,7 +38,8 @@ app.post("/ufo/upload", uploadLimiter, upload.single("file"), (req, res) => {
 
   console.log("Received uploaded file:", req.file.originalname);
 
-  const uploadedFilePath = path.join(__dirname, req.file.originalname);
+  const sanitizedFilename = sanitizeFilename(req.file.originalname);
+  const uploadedFilePath = path.join(__dirname, sanitizedFilename);
   fs.writeFileSync(uploadedFilePath, req.file.buffer);
 
   res.status(200).send("File uploaded successfully.");

--- a/Season-2/Level-3/package.json
+++ b/Season-2/Level-3/package.json
@@ -16,7 +16,8 @@
       "libxmljs": "^1.0.9",
       "multer": "^2.0.1",
       "path": "^0.12.7",
-      "express-rate-limit": "^7.5.0"
+      "express-rate-limit": "^7.5.0",
+      "sanitize-filename": "^1.6.3"
     },
     "devDependencies": {
       "chai": "^4.3.8",


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/vigilant-octo/security/code-scanning/17](https://github.com/akabarki76/vigilant-octo/security/code-scanning/17)

To fix the issue, we need to sanitize the user-provided filename (`req.file.originalname`) before using it to construct the file path. The best approach is to use a library like `sanitize-filename` to remove any potentially dangerous characters or sequences from the filename. This ensures that the resulting filename is safe and does not contain path traversal sequences or other malicious content.

Steps to fix:
1. Install the `sanitize-filename` npm package if it is not already installed.
2. Import the `sanitize-filename` library in the file.
3. Use `sanitize-filename` to sanitize `req.file.originalname` before passing it to `path.join`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
