### PR TITLE
Potential fix for code scanning alert no. 3: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/code.py
+++ b/Season-1/Level-5/code.py
@@ -28,15 +28,13 @@ class SHA256_hasher:
 
     # produces the password hash by combining password + salt because hashing
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_hash = bcrypt.hashpw(password.encode(), salt)
         return password_hash.decode('ascii')
 
     # verifies that the hashed password reverses to the plain text version on verification
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
         password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        return bcrypt.checkpw(password.encode(), password_hash)
 
 class MD5_hasher:
 


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/vigilant-octo/security/code-scanning/3](https://github.com/akabarki76/vigilant-octo/security/code-scanning/3)

To fix the issue, we will replace the use of SHA-256 for hashing passwords with bcrypt directly. Bcrypt is computationally expensive and includes salting by default, making it suitable for password hashing. This change will simplify the code and ensure it adheres to cryptographic best practices.

Steps to implement the fix:
1. Remove the use of SHA-256 in the `SHA256_hasher` class.
2. Modify the `password_hash` and `password_verification` methods to use bcrypt directly.
3. Ensure that a proper salt is generated and used with bcrypt.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
